### PR TITLE
Fix: bumpver pep440 resolution of pre-releases

### DIFF
--- a/requirements/pypi.txt
+++ b/requirements/pypi.txt
@@ -16,6 +16,10 @@ lexid
 colorama>=0.4
 enum34; python_version < "3.4"
 
+# packaging.version.Version is the PEP 440 implementation
+# (formerly accessed via pkg_resources.parse_version, now deprecated)
+packaging
+
 # looseversion is needed to parse non PEP440 versions
 looseversion; python_version >= "3.5"
 

--- a/src/bumpver/version.py
+++ b/src/bumpver/version.py
@@ -13,9 +13,9 @@ def parse_version(version: str) -> typ.Any:
     # pylint: disable=import-outside-toplevel; lazy import to speed up --help
 
     try:
-        import pkg_resources
+        from packaging.version import Version
 
-        return pkg_resources.parse_version(version)
+        return Version(version)
     except (ImportError, ValueError):
         import looseversion
 

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -311,3 +311,24 @@ PEP440_TEST_CASES = [
 @pytest.mark.parametrize("version_str, expected", PEP440_TEST_CASES)
 def test_to_pep440(version_str, expected):
     assert version.to_pep440(version_str) == expected
+
+
+PRERELEASE_LT_FINAL_CASES = [
+    ("1.2.3a0",  "1.2.3"),
+    ("1.2.3b0",  "1.2.3"),
+    ("1.2.3rc0", "1.2.3"),
+    ("1.2.3rc2", "1.2.3"),
+    ("1.2.3",    "1.2.4"),
+]
+
+
+@pytest.mark.parametrize("lower, higher", PRERELEASE_LT_FINAL_CASES)
+def test_parse_version_prerelease_lt_final(lower, higher):
+    assert version.parse_version(lower) < version.parse_version(higher)
+    assert not version.parse_version(higher) < version.parse_version(lower)
+
+
+def test_parse_version_prerelease_chain():
+    vs = [version.parse_version(s) for s in ("1.2.3a0", "1.2.3b0", "1.2.3rc0", "1.2.3")]
+    assert vs == sorted(vs)
+    assert vs[0] < vs[1] < vs[2] < vs[3]


### PR DESCRIPTION
Fix version comparisons for pre-releases by using modern packaging dependency.